### PR TITLE
chore: add .gitattributes to enforce cross-os line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Handle line endings for all text files
+* text=auto eol=lf
+
+# Ensure binary files (like images) aren't touched
+*.png binary
+*.jpg binary


### PR DESCRIPTION
## What’s this PR do?
Add .gitattributes to enforce cross-os line endings

## Related issue(s)
N/A

## How to test

- [x] Run tests locally
- [] Start app and confirm functionality

## Notes for reviewers
N/A