### PR TITLE
chore: add pre-commit hook to auto-update uv.lock after pyproject.tom…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,12 @@ repos:
         # Use pyproject.toml for config
         additional_dependencies: ["toml"]
         files: \.(py|md|txt)$
+
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version
+    rev: 0.11.26
+    hooks:
+      # Make sure uv.lock is up to date even if pyproject.toml file was changed.
+      - id: uv-lock
+        args: ["--project=backend"]
+        files: ^backend/pyproject.toml$


### PR DESCRIPTION
## What’s this PR do?
Add pre-commit hook to auto-update uv.lock after pyproject.toml change. Closes #84 

## Related issue(s)
#84

## How to test

- [x] Run tests locally
- [] Start app and confirm functionality

## Notes for reviewers
