### PR TITLE
chore: remove non-docker tasks from root makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Configuration
+# Docker Commands
 # -----------------------------------------------------------------------------
 
 # Docker service name (as defined in docker-compose.yml)
@@ -7,33 +7,8 @@ WEB=web
 
 # Tells Make to always run the specified targes,
 # even if folders/files with the same name exist in the root directory.
-.PHONY: migrate migrations createsuperuser shell up up-detach down build rebuild test lint lint-fix format format-diff spellcheck
+.PHONY: up up-detach down build rebuild
 
-
-# -----------------------------------------------------------------------------
-# Django Management Commands
-# -----------------------------------------------------------------------------
-
-# Apply all database migrations
-migrate:
-	docker compose run --rm $(WEB) uv run manage.py migrate
-
-# Create new migration files based on model changes
-migrations:
-	docker compose run --rm $(WEB) uv run manage.py makemigrations
-
-# Create a Django superuser (interactive)
-createsuperuser:
-	docker compose exec $(WEB) uv run manage.py createsuperuser
-
-# Open the Django shell inside the container
-shell:
-	docker compose exec $(WEB) uv run manage.py shell
-
-
-# -----------------------------------------------------------------------------
-# Docker Compose Commands
-# -----------------------------------------------------------------------------
 
 # Start all services (foreground)
 up:
@@ -54,31 +29,3 @@ build:
 # Rebuild containers from scratch (no cache)
 rebuild:
 	docker compose build --no-cache
-
-
-# -----------------------------------------------------------------------------
-# Testing & Code Quality (Run locally for speed)
-# -----------------------------------------------------------------------------
-
-# Run all tests inside the container
-test:
-	docker compose run --rm -T $(WEB) uv run pytest --color=yes
-
-# Run ruff to check for linting issues locally
-lint:
-	cd backend && uv run ruff check .
-
-# Automatically fix fixable linting issues
-lint-fix:
-	cd backend && uv run ruff check --fix .
-
-# Format code according to project style guidelines
-format:
-	cd backend && uv run ruff format .
-
-format-diff:
-	cd backend && uv run ruff format --diff .
-
-# Run spellcheck on codebase
-spellcheck:
-	uvx codespell .


### PR DESCRIPTION
## What’s this PR do?
Remove non-Docker commands from root Makefile. Directory run uv commands in backend terminal (`uv run pytest`).

## Related issue(s)
n/a

## How to test

- [x] Run tests locally
- [] Start app and confirm functionality

## Notes for reviewers
n/a