### PR TITLE
Chore/add renovate group for docker and python prod deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,15 @@
       "groupName": "Python dev dependencies"
     },
     {
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "excludePackageNames": [
+        "django"
+      ],
+      "groupName": "Python prod dependencies"
+    },
+    {
       "matchPackageNames": [
         "django"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,13 @@
         "django"
       ],
       "groupName": "Django"
+    },
+    {
+      "matchManagers": [
+        "dockerfile",
+        "docker-compose"
+      ],
+      "groupName": "Docker images"
     }
   ]
 }


### PR DESCRIPTION
## What’s this PR do?
Add renovate groups for docker and python prod dependencies.

## Related issue(s)
n/a

## How to test

- [x] Run tests locally
- [] Start app and confirm functionality

## Notes for reviewers
n/a